### PR TITLE
Add meal plan persistence and meal plan generation endpoint

### DIFF
--- a/src/main/kotlin/application/dto/SyncDtos.kt
+++ b/src/main/kotlin/application/dto/SyncDtos.kt
@@ -7,7 +7,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class SyncPushRequest(
     val recipes: List<SyncRecipe>,
-    val bookmarkedRecipes: List<SyncBookmark> = emptyList()
+    val bookmarkedRecipes: List<SyncBookmark> = emptyList(),
+    val mealPlans: List<SyncMealPlanDto> = emptyList()
 )
 
 @Serializable
@@ -55,7 +56,8 @@ data class SyncPushResponse(
     /** Reference entities required to resolve every [ConflictEntity.serverVersion] locally. */
     val referenceData: SyncReferenceData,
     @EncodeDefault val bookmarkedRecipes: List<BookmarkPushResult> = emptyList(),
-    @EncodeDefault val bookmarkErrors: List<BookmarkPushError> = emptyList()
+    @EncodeDefault val bookmarkErrors: List<BookmarkPushError> = emptyList(),
+    @EncodeDefault val mealPlans: MealPlanPushResults = MealPlanPushResults()
 )
 
 @Serializable
@@ -203,6 +205,49 @@ data class SyncPullResponse(
     val tags: List<SyncTag>,
     val labels: List<SyncLabel>,
     @EncodeDefault val bookmarkedRecipes: List<SyncBookmark> = emptyList(),
+    @EncodeDefault val mealPlans: List<SyncMealPlanDto> = emptyList(),
     val serverTimestamp: Long,
     val hasMore: Boolean
+)
+
+// ── Meal Plan DTOs ──────────────────────────────────────────────────────────
+
+@Serializable
+data class SyncMealPlanDto(
+    val uuid: String,
+    val name: String,
+    val status: String,
+    val preferencesJson: String,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val deletedAt: Long?,
+    val days: List<SyncMealPlanDayDto>
+)
+
+@Serializable
+data class SyncMealPlanDayDto(
+    val uuid: String,
+    val dayIndex: Int,
+    val dinnerRecipeId: String?,
+    val lunchRecipeId: String?
+)
+
+@Serializable
+data class MealPlanPushResult(
+    val uuid: String,
+    val serverUpdatedAt: Long
+)
+
+@Serializable
+data class MealPlanPushResults(
+    val accepted: List<MealPlanPushResult> = emptyList(),
+    val conflicts: List<String> = emptyList(),
+    val errors: List<SyncError> = emptyList()
+)
+
+@Serializable
+data class GenerateMealPlanResponse(
+    val uuid: String,
+    val status: String,
+    val updatedAt: Long
 )

--- a/src/main/kotlin/application/service/Application.kt
+++ b/src/main/kotlin/application/service/Application.kt
@@ -5,6 +5,7 @@ import com.tenmilelabs.domain.repository.SyncRepository
 import com.tenmilelabs.domain.service.AuthService
 import com.tenmilelabs.domain.service.HomeLayoutService
 import com.tenmilelabs.domain.service.JwtService
+import com.tenmilelabs.domain.service.MealPlanGenerationService
 import com.tenmilelabs.domain.service.RecipesService
 import com.tenmilelabs.domain.service.SoftDeletePurgeConfig
 import com.tenmilelabs.domain.service.SoftDeletePurgeService
@@ -40,6 +41,7 @@ fun Application.module(
         },
         log = log,
     ),
+    mealPlanGenerationService: MealPlanGenerationService? = null,
     configureDatabase: Boolean = true,
 ) {
     val recipeRepository = recipeRepository
@@ -57,6 +59,12 @@ fun Application.module(
     val softDeletePurgeService = SoftDeletePurgeService(recipeRepository, log)
     val syncService = SyncService(syncRepository, log)
 
+    val resolvedMealPlanGenerationService = mealPlanGenerationService ?: run {
+        val generationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        monitor.subscribe(ApplicationStopping) { generationScope.cancel() }
+        MealPlanGenerationService(syncRepository, generationScope, log)
+    }
+
     // Set up plugins
     if (configureDatabase) {
         configureDatabases()
@@ -68,6 +76,7 @@ fun Application.module(
         authService = authService,
         syncService = syncService,
         homeLayoutService = homeLayoutService,
+        mealPlanGenerationService = resolvedMealPlanGenerationService,
     )
 
     val purgeConfig = softDeletePurgeConfig()

--- a/src/main/kotlin/domain/repository/SyncRepository.kt
+++ b/src/main/kotlin/domain/repository/SyncRepository.kt
@@ -1,6 +1,8 @@
 package com.tenmilelabs.domain.repository
 
 import com.tenmilelabs.application.dto.SyncBookmark
+import com.tenmilelabs.application.dto.SyncMealPlanDto
+import com.tenmilelabs.application.dto.SyncMealPlanDayDto
 import com.tenmilelabs.application.dto.SyncRecipe
 import com.tenmilelabs.application.dto.SyncReferenceData
 import com.tenmilelabs.application.dto.SyncUser
@@ -9,6 +11,11 @@ import java.util.UUID
 
 data class SyncRecipeRecord(
     val recipe: SyncRecipe,
+    val serverUpdatedAtMillis: Long
+)
+
+data class SyncMealPlanRecord(
+    val plan: SyncMealPlanDto,
     val serverUpdatedAtMillis: Long
 )
 
@@ -126,4 +133,58 @@ interface SyncRepository {
      * Includes tombstones (deleted_at non-null) so the client can handle removals.
      */
     suspend fun findDeltaBookmarks(userId: UUID, sinceMillis: Long): List<SyncBookmark>
+
+    // ── Meal Plans ────────────────────────────────────────────────────────────
+
+    /**
+     * Loads a single meal plan by [uuid] scoped to [userId].
+     * Returns null if not found or owned by a different user.
+     */
+    suspend fun getMealPlanForUser(uuid: UUID, userId: UUID): SyncMealPlanRecord?
+
+    /**
+     * Upserts a meal plan using last-writer-wins semantics on [updated_at].
+     * Replaces all [meal_plan_days] rows atomically (delete + re-insert).
+     * When [plan.deletedAt] is non-null the plan is soft-deleted.
+     */
+    suspend fun upsertMealPlan(plan: SyncMealPlanDto, userId: UUID, serverUpdatedAt: Instant)
+
+    /**
+     * Returns meal plans for [userId] whose [server_updated_at] is after [sinceMillis].
+     * Includes soft-deleted plans (deletedAt non-null) so the client can tombstone them.
+     * Days are nested inside each returned plan.
+     */
+    suspend fun findDeltaMealPlans(userId: UUID, sinceMillis: Long): List<SyncMealPlanRecord>
+
+    /**
+     * Sets the [status] field and bumps [server_updated_at] on the given plan.
+     * Used by the generation pipeline to transition DRAFT → GENERATING → READY.
+     */
+    suspend fun updateMealPlanStatus(planId: UUID, status: String, serverUpdatedAt: Instant)
+
+    /**
+     * Replaces all day rows for [planId] atomically.
+     * Used by the generation pipeline after recipe assignment is complete.
+     */
+    suspend fun replaceMealPlanDays(planId: UUID, days: List<SyncMealPlanDayDto>)
+
+    /**
+     * Returns recipe UUIDs that are candidates for meal plan generation given
+     * the provided filter criteria.
+     *
+     * [recipeSource] — "COLLECTION_ONLY" limits to bookmarked recipes; "INCLUDE_PUBLIC"
+     * includes all recipes owned by [userId] or marked PUBLIC.
+     *
+     * [dietaryRestrictionTags] — tag display names (e.g. "VEGAN", "GLUTEN_FREE") that
+     * a candidate recipe must ALL be tagged with. Empty list means no restriction.
+     *
+     * [maxPrepTimeMinutes] — upper bound on prep_time_minutes + cook_time_minutes.
+     * Null means no time constraint.
+     */
+    suspend fun findCandidateRecipeIds(
+        userId: UUID,
+        recipeSource: String,
+        dietaryRestrictionTags: List<String>,
+        maxPrepTimeMinutes: Int?
+    ): List<UUID>
 }

--- a/src/main/kotlin/domain/service/MealPlanGenerationService.kt
+++ b/src/main/kotlin/domain/service/MealPlanGenerationService.kt
@@ -1,0 +1,235 @@
+package com.tenmilelabs.domain.service
+
+import com.tenmilelabs.application.dto.GenerateMealPlanResponse
+import com.tenmilelabs.application.dto.SyncMealPlanDayDto
+import com.tenmilelabs.domain.repository.SyncRepository
+import io.ktor.util.logging.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.*
+import java.util.UUID
+import kotlin.collections.ArrayDeque
+import kotlin.collections.List
+import kotlin.collections.emptyList
+import kotlin.collections.filter
+import kotlin.collections.firstOrNull
+import kotlin.collections.last
+import kotlin.collections.map
+import kotlin.collections.mutableListOf
+import kotlin.collections.plusAssign
+import kotlin.collections.shuffled
+import kotlin.collections.takeLast
+import kotlin.collections.toSet
+
+/**
+ * Handles the async AI-style meal plan generation pipeline.
+ *
+ * Flow:
+ * 1. [startGeneration] validates ownership, transitions plan to GENERATING, returns 202 payload.
+ * 2. A background coroutine runs [generateAsync]: finds candidate recipes, assigns them to days,
+ *    replaces meal_plan_days rows, then sets status to READY.
+ */
+class MealPlanGenerationService(
+    private val syncRepository: SyncRepository,
+    private val generationScope: CoroutineScope,
+    private val log: Logger
+) {
+    /**
+     * Validates that [userId] owns [mealPlanId], transitions the plan to GENERATING status,
+     * launches the async generation pipeline, and returns the 202 payload.
+     *
+     * Returns null if the plan is not found or not owned by [userId].
+     */
+    suspend fun startGeneration(mealPlanId: UUID, userId: UUID): GenerateMealPlanResponse? {
+        val record = syncRepository.getMealPlanForUser(mealPlanId, userId) ?: return null
+
+        val now = Clock.System.now()
+        syncRepository.updateMealPlanStatus(mealPlanId, STATUS_GENERATING, now)
+        log.info("Meal plan $mealPlanId set to GENERATING for user $userId")
+
+        generationScope.launch {
+            generateAsync(mealPlanId, userId, record.plan.preferencesJson)
+        }
+
+        return GenerateMealPlanResponse(
+            uuid = mealPlanId.toString(),
+            status = STATUS_GENERATING,
+            updatedAt = now.toEpochMilliseconds()
+        )
+    }
+
+    // ── Internal generation pipeline ──────────────────────────────────────────
+
+    private suspend fun generateAsync(planId: UUID, userId: UUID, preferencesJson: String) {
+        try {
+            val prefs = parsePreferences(preferencesJson)
+
+            val candidateIds = syncRepository.findCandidateRecipeIds(
+                userId = userId,
+                recipeSource = prefs.recipeSource,
+                dietaryRestrictionTags = prefs.dietaryRestrictions.filter { it != "NONE" },
+                maxPrepTimeMinutes = prefs.maxPrepTimeMinutes
+            )
+
+            val days = assignRecipesToDays(candidateIds, prefs)
+
+            val now = Clock.System.now()
+            syncRepository.replaceMealPlanDays(planId, days)
+            syncRepository.updateMealPlanStatus(planId, STATUS_READY, now)
+            log.info("Meal plan $planId generation complete: ${days.size} days assigned for user $userId")
+        } catch (ex: Exception) {
+            log.error("Meal plan $planId generation failed for user $userId", ex)
+            // Leave status as GENERATING so the client can detect the stall and retry if needed.
+        }
+    }
+
+    /**
+     * Assigns candidate recipe UUIDs to plan days according to [prefs].
+     *
+     * Variety rules:
+     * - HIGH: no recipe repeats across all slots in the plan. Slots are left null when
+     *   candidates are exhausted (partial fill — status still set to READY).
+     * - MEDIUM: a recipe may reappear only after a 3-day gap; cycles when all are blocked.
+     * - LOW: free repetition — cycles round-robin through the candidate list.
+     *
+     * Batch-cooking: when [prefs.batchCooking] is true, odd-indexed days reuse the previous
+     * day's assignment (pairs intentionally share a recipe for batch-prep efficiency).
+     */
+    internal fun assignRecipesToDays(
+        candidateIds: List<UUID>,
+        prefs: MealPlanPreferences
+    ): List<SyncMealPlanDayDto> {
+        if (candidateIds.isEmpty()) return buildEmptyDays(prefs.planLengthDays)
+
+        val shuffled = candidateIds.shuffled()
+        val days = mutableListOf<SyncMealPlanDayDto>()
+        val dinnerHistory = ArrayDeque<UUID>()
+        val lunchHistory = ArrayDeque<UUID>()
+
+        for (dayIndex in 0 until prefs.planLengthDays) {
+            val dinnerRecipeId: UUID?
+            val lunchRecipeId: UUID?
+
+            if (prefs.batchCooking && dayIndex > 0 && dayIndex % 2 == 1) {
+                // Batch day: reuse the previous day's recipe for intentional batch prep
+                dinnerRecipeId = days.last().dinnerRecipeId?.let { UUID.fromString(it) }
+                lunchRecipeId = days.last().lunchRecipeId?.let { UUID.fromString(it) }
+            } else {
+                dinnerRecipeId = pickFrom(shuffled, dinnerHistory, prefs.varietyPreference)
+                dinnerRecipeId?.let { dinnerHistory.addLast(it) }
+
+                lunchRecipeId = if (prefs.mealType == MealType.DINNER_AND_LUNCH) {
+                    pickFrom(shuffled, lunchHistory, prefs.varietyPreference)
+                        .also { it?.let { id -> lunchHistory.addLast(id) } }
+                } else null
+            }
+
+            days += SyncMealPlanDayDto(
+                uuid = UUID.randomUUID().toString(),
+                dayIndex = dayIndex,
+                dinnerRecipeId = dinnerRecipeId?.toString(),
+                lunchRecipeId = lunchRecipeId?.toString()
+            )
+        }
+
+        return days
+    }
+
+    /**
+     * Picks the next recipe from [candidates] without consuming the list, using [history]
+     * to track previously assigned recipes.
+     *
+     * - HIGH: must not appear anywhere in history; returns null when all candidates are used.
+     * - MEDIUM: must not appear in the last 3 history entries; cycles when all are blocked.
+     * - LOW: round-robin via `history.size % candidates.size` — always succeeds.
+     */
+    private fun pickFrom(
+        candidates: List<UUID>,
+        history: ArrayDeque<UUID>,
+        variety: VarietyPreference
+    ): UUID? {
+        if (candidates.isEmpty()) return null
+        return when (variety) {
+            VarietyPreference.LOW ->
+                candidates[history.size % candidates.size]
+            VarietyPreference.MEDIUM -> {
+                val recent = history.takeLast(3).toSet()
+                candidates.firstOrNull { it !in recent }
+                    ?: candidates[history.size % candidates.size]
+            }
+            VarietyPreference.HIGH -> {
+                val used = history.toSet()
+                candidates.firstOrNull { it !in used }
+            }
+        }
+    }
+
+    private fun buildEmptyDays(count: Int): List<SyncMealPlanDayDto> =
+        (0 until count).map { idx ->
+            SyncMealPlanDayDto(
+                uuid = UUID.randomUUID().toString(),
+                dayIndex = idx,
+                dinnerRecipeId = null,
+                lunchRecipeId = null
+            )
+        }
+
+    // ── Preferences parsing ───────────────────────────────────────────────────
+
+    internal fun parsePreferences(json: String): MealPlanPreferences {
+        val obj: JsonObject = lenientJson.parseToJsonElement(json).jsonObject
+
+        val planLengthDays = obj["planLengthDays"]?.jsonPrimitive?.intOrNull ?: 7
+        val mealType = obj["mealType"]?.jsonPrimitive?.content
+            ?.let { runCatching { MealType.valueOf(it) }.getOrNull() }
+            ?: MealType.DINNER
+        val dietaryRestrictions = obj["dietaryRestrictions"]?.jsonArray
+            ?.map { it.jsonPrimitive.content }
+            ?: emptyList()
+        val recipeSource = obj["recipeSource"]?.jsonPrimitive?.content ?: "INCLUDE_PUBLIC"
+        val maxPrepTimeMinutes = obj["maxPrepTimeMinutes"]?.jsonPrimitive?.intOrNull
+        val servingsPerMeal = obj["servingsPerMeal"]?.jsonPrimitive?.intOrNull ?: 2
+        val batchCooking = obj["batchCooking"]?.jsonPrimitive?.booleanOrNull ?: false
+        val leftoverFriendly = obj["leftoverFriendly"]?.jsonPrimitive?.booleanOrNull ?: false
+        val varietyPreference = obj["varietyPreference"]?.jsonPrimitive?.content
+            ?.let { runCatching { VarietyPreference.valueOf(it) }.getOrNull() }
+            ?: VarietyPreference.HIGH
+
+        return MealPlanPreferences(
+            planLengthDays = planLengthDays.coerceAtLeast(1),
+            mealType = mealType,
+            dietaryRestrictions = dietaryRestrictions,
+            recipeSource = recipeSource,
+            maxPrepTimeMinutes = maxPrepTimeMinutes?.takeIf { it > 0 },
+            servingsPerMeal = servingsPerMeal,
+            batchCooking = batchCooking,
+            leftoverFriendly = leftoverFriendly,
+            varietyPreference = varietyPreference
+        )
+    }
+
+    companion object {
+        const val STATUS_GENERATING = "GENERATING"
+        const val STATUS_READY = "READY"
+
+        private val lenientJson = Json { ignoreUnknownKeys = true }
+    }
+}
+
+// ── Domain value types (package-private) ─────────────────────────────────────
+
+data class MealPlanPreferences(
+    val planLengthDays: Int,
+    val mealType: MealType,
+    val dietaryRestrictions: List<String>,
+    val recipeSource: String,
+    val maxPrepTimeMinutes: Int?,
+    val servingsPerMeal: Int,
+    val batchCooking: Boolean,
+    val leftoverFriendly: Boolean,
+    val varietyPreference: VarietyPreference
+)
+
+enum class MealType { DINNER, DINNER_AND_LUNCH }
+enum class VarietyPreference { HIGH, MEDIUM, LOW }

--- a/src/main/kotlin/domain/service/SyncService.kt
+++ b/src/main/kotlin/domain/service/SyncService.kt
@@ -6,8 +6,11 @@ import com.tenmilelabs.application.dto.BookmarkPushError
 import com.tenmilelabs.application.dto.BookmarkPushResult
 import com.tenmilelabs.application.dto.ConflictEntity
 import com.tenmilelabs.application.dto.ConflictReasons
+import com.tenmilelabs.application.dto.MealPlanPushResult
+import com.tenmilelabs.application.dto.MealPlanPushResults
 import com.tenmilelabs.application.dto.SyncError
 import com.tenmilelabs.application.dto.SyncErrors
+import com.tenmilelabs.application.dto.SyncMealPlanDto
 import com.tenmilelabs.application.dto.SyncPullResponse
 import com.tenmilelabs.application.dto.SyncPushRequest
 import com.tenmilelabs.application.dto.SyncPushResponse
@@ -134,6 +137,7 @@ class SyncService(
         }
 
         val (bookmarkResults, bookmarkErrors) = processBookmarks(userId, request)
+        val mealPlanResults = processMealPlans(userId, request.mealPlans)
 
         return SyncPushResponse(
             accepted = accepted,
@@ -142,8 +146,40 @@ class SyncService(
             serverTimestamp = Clock.System.now().toEpochMilliseconds(),
             referenceData = conflictReferenceData,
             bookmarkedRecipes = bookmarkResults,
-            bookmarkErrors = bookmarkErrors
+            bookmarkErrors = bookmarkErrors,
+            mealPlans = mealPlanResults
         )
+    }
+
+    private suspend fun processMealPlans(
+        userId: UUID,
+        mealPlans: List<SyncMealPlanDto>
+    ): MealPlanPushResults {
+        if (mealPlans.isEmpty()) return MealPlanPushResults()
+
+        val accepted = mutableListOf<MealPlanPushResult>()
+        val conflicts = mutableListOf<String>()
+        val errors = mutableListOf<SyncError>()
+
+        mealPlans.forEach { plan ->
+            val planUuid = parseUuid(plan.uuid) {
+                errors += SyncError(plan.uuid, SyncErrors.INVALID_UUID, SyncErrors.INVALID_UUID.message)
+            } ?: return@forEach
+
+            val existing = syncRepository.getMealPlanForUser(planUuid, userId)
+            if (existing != null && existing.serverUpdatedAtMillis > plan.updatedAt) {
+                conflicts += plan.uuid
+                log.info("Meal plan push conflict for user $userId, planId=${plan.uuid}: server is newer")
+                return@forEach
+            }
+
+            val now = Clock.System.now()
+            syncRepository.upsertMealPlan(plan, userId, now)
+            accepted += MealPlanPushResult(uuid = plan.uuid, serverUpdatedAt = now.toEpochMilliseconds())
+            log.info("Meal plan push accepted for user $userId, planId=${plan.uuid}")
+        }
+
+        return MealPlanPushResults(accepted = accepted, conflicts = conflicts, errors = errors)
     }
 
     private suspend fun processBookmarks(
@@ -259,13 +295,14 @@ class SyncService(
         )
 
         val bookmarks = syncRepository.findDeltaBookmarks(userId, sinceMillis)
+        val mealPlans = syncRepository.findDeltaMealPlans(userId, sinceMillis)
 
         log.info(
             "Sync pull for user $userId: recipes=${page.size}, hasMore=$hasMore, " +
                 "ingredients=${refData.ingredients.size}, allergens=${refData.allergens.size}, " +
                 "sourceClassifications=${refData.sourceClassifications.size}, " +
                 "tags=${refData.tags.size}, labels=${refData.labels.size}, " +
-                "bookmarks=${bookmarks.size}"
+                "bookmarks=${bookmarks.size}, mealPlans=${mealPlans.size}"
         )
 
         return SyncPullResponse(
@@ -277,6 +314,7 @@ class SyncService(
             tags = refData.tags,
             labels = refData.labels,
             bookmarkedRecipes = bookmarks,
+            mealPlans = mealPlans.map { it.plan },
             serverTimestamp = cursor,
             hasMore = hasMore
         )

--- a/src/main/kotlin/infrastructure/database/DatabaseInit.kt
+++ b/src/main/kotlin/infrastructure/database/DatabaseInit.kt
@@ -8,6 +8,8 @@ import com.tenmilelabs.infrastructure.database.tables.AllergenTable
 import com.tenmilelabs.infrastructure.database.tables.BookmarkedRecipeTable
 import com.tenmilelabs.infrastructure.database.tables.IngredientTable
 import com.tenmilelabs.infrastructure.database.tables.LabelTable
+import com.tenmilelabs.infrastructure.database.tables.MealPlanDayTable
+import com.tenmilelabs.infrastructure.database.tables.MealPlanTable
 import com.tenmilelabs.infrastructure.database.tables.RecipeIngredientTable
 import com.tenmilelabs.infrastructure.database.tables.RecipeLabelTable
 import com.tenmilelabs.infrastructure.database.tables.RecipeStepTable
@@ -37,7 +39,9 @@ fun initDatabaseAndSchema() {
             RefreshTokenTable,
             SourceClassificationTable,
             TagTable,
-            BookmarkedRecipeTable
+            BookmarkedRecipeTable,
+            MealPlanTable,
+            MealPlanDayTable
         )
     }
 }

--- a/src/main/kotlin/infrastructure/database/repositoryImpl/PostgresSyncRepository.kt
+++ b/src/main/kotlin/infrastructure/database/repositoryImpl/PostgresSyncRepository.kt
@@ -1,16 +1,7 @@
 package com.tenmilelabs.infrastructure.database.repositoryImpl
 
-import com.tenmilelabs.application.dto.SyncAllergen
-import com.tenmilelabs.application.dto.SyncBookmark
-import com.tenmilelabs.application.dto.SyncIngredient
-import com.tenmilelabs.application.dto.SyncLabel
-import com.tenmilelabs.application.dto.SyncRecipe
-import com.tenmilelabs.application.dto.SyncRecipeIngredient
-import com.tenmilelabs.application.dto.SyncRecipeStep
-import com.tenmilelabs.application.dto.SyncReferenceData
-import com.tenmilelabs.application.dto.SyncSourceClassification
-import com.tenmilelabs.application.dto.SyncTag
-import com.tenmilelabs.application.dto.SyncUser
+import com.tenmilelabs.application.dto.*
+import com.tenmilelabs.domain.repository.SyncMealPlanRecord
 import com.tenmilelabs.domain.repository.SyncRecipeRecord
 import com.tenmilelabs.domain.repository.SyncRepository
 import com.tenmilelabs.infrastructure.database.mappers.suspendTransaction
@@ -454,6 +445,198 @@ class PostgresSyncRepository : SyncRepository {
                     deletedAt = row[BookmarkedRecipeTable.deleted_at]?.toEpochMilliseconds()
                 )
             }
+    }
+
+    // ── Meal Plans ────────────────────────────────────────────────────────────
+
+    override suspend fun getMealPlanForUser(uuid: UUID, userId: UUID): SyncMealPlanRecord? = suspendTransaction {
+        val planRow = MealPlanTable
+            .selectAll()
+            .where {
+                (MealPlanTable.id eq uuid) and (MealPlanTable.user_id eq EntityID(userId, UserTable))
+            }
+            .firstOrNull() ?: return@suspendTransaction null
+        toSyncMealPlanRecord(planRow)
+    }
+
+    override suspend fun upsertMealPlan(plan: SyncMealPlanDto, userId: UUID, serverUpdatedAt: Instant) =
+        suspendTransaction {
+            val planUuid = UUID.fromString(plan.uuid)
+            val planEntityId = EntityID(planUuid, MealPlanTable)
+
+            val exists = MealPlanTable
+                .selectAll()
+                .where { MealPlanTable.id eq planUuid }
+                .limit(1)
+                .any()
+
+            if (exists) {
+                MealPlanTable.update({ MealPlanTable.id eq planUuid }) {
+                    it[name] = plan.name
+                    it[status] = plan.status
+                    it[preferences] = plan.preferencesJson
+                    it[updated_at] = plan.updatedAt
+                    it[deleted_at] = plan.deletedAt
+                    it[MealPlanTable.server_updated_at] = serverUpdatedAt
+                }
+            } else {
+                MealPlanTable.insert {
+                    it[id] = planEntityId
+                    it[user_id] = EntityID(userId, UserTable)
+                    it[name] = plan.name
+                    it[status] = plan.status
+                    it[preferences] = plan.preferencesJson
+                    it[created_at] = plan.createdAt
+                    it[updated_at] = plan.updatedAt
+                    it[deleted_at] = plan.deletedAt
+                    it[MealPlanTable.server_updated_at] = serverUpdatedAt
+                }
+            }
+
+            // Replace days atomically
+            MealPlanDayTable.deleteWhere { MealPlanDayTable.meal_plan_id eq planEntityId }
+            plan.days.forEach { day ->
+                MealPlanDayTable.insert {
+                    it[MealPlanDayTable.id] = EntityID(UUID.fromString(day.uuid), MealPlanDayTable)
+                    it[meal_plan_id] = planEntityId
+                    it[day_index] = day.dayIndex
+                    it[dinner_recipe_id] = day.dinnerRecipeId?.let { id -> EntityID(UUID.fromString(id), RecipeTable) }
+                    it[lunch_recipe_id] = day.lunchRecipeId?.let { id -> EntityID(UUID.fromString(id), RecipeTable) }
+                }
+            }
+        }
+
+    override suspend fun findDeltaMealPlans(userId: UUID, sinceMillis: Long): List<SyncMealPlanRecord> =
+        suspendTransaction {
+            val sinceInstant = Instant.fromEpochMilliseconds(sinceMillis)
+            MealPlanTable
+                .selectAll()
+                .where {
+                    (MealPlanTable.user_id eq EntityID(userId, UserTable)) and
+                        (MealPlanTable.server_updated_at greater sinceInstant)
+                }
+                .orderBy(MealPlanTable.server_updated_at to SortOrder.ASC)
+                .map(::toSyncMealPlanRecord)
+        }
+
+    override suspend fun updateMealPlanStatus(planId: UUID, status: String, serverUpdatedAt: Instant): Unit =
+        suspendTransaction {
+            MealPlanTable.update({ MealPlanTable.id eq planId }) {
+                it[MealPlanTable.status] = status
+                it[MealPlanTable.server_updated_at] = serverUpdatedAt
+            }
+        }
+
+    override suspend fun replaceMealPlanDays(planId: UUID, days: List<SyncMealPlanDayDto>): Unit =
+        suspendTransaction {
+            val planEntityId = EntityID(planId, MealPlanTable)
+            MealPlanDayTable.deleteWhere { MealPlanDayTable.meal_plan_id eq planEntityId }
+            days.forEach { day ->
+                MealPlanDayTable.insert {
+                    it[MealPlanDayTable.id] = EntityID(UUID.fromString(day.uuid), MealPlanDayTable)
+                    it[meal_plan_id] = planEntityId
+                    it[day_index] = day.dayIndex
+                    it[dinner_recipe_id] = day.dinnerRecipeId?.let { id -> EntityID(UUID.fromString(id), RecipeTable) }
+                    it[lunch_recipe_id] = day.lunchRecipeId?.let { id -> EntityID(UUID.fromString(id), RecipeTable) }
+                }
+            }
+        }
+
+    override suspend fun findCandidateRecipeIds(
+        userId: UUID,
+        recipeSource: String,
+        dietaryRestrictionTags: List<String>,
+        maxPrepTimeMinutes: Int?
+    ): List<UUID> = suspendTransaction {
+        // Step 1: Resolve tag IDs for dietary restrictions (match by display_name, case-insensitive)
+        val restrictionTagIds: List<EntityID<UUID>> = if (dietaryRestrictionTags.isEmpty()) {
+            emptyList()
+        } else {
+            val upperNames = dietaryRestrictionTags.map { it.uppercase() }
+            TagTable.selectAll()
+                .where { TagTable.display_name.upperCase() inList upperNames }
+                .map { it[TagTable.id] }
+        }
+
+        // Step 2: Build the base set of accessible recipe IDs per recipeSource
+        val accessibleIds: Set<UUID> = when (recipeSource) {
+            "COLLECTION_ONLY" -> BookmarkedRecipeTable
+                .selectAll()
+                .where {
+                    (BookmarkedRecipeTable.user_id eq EntityID(userId, UserTable)) and
+                        BookmarkedRecipeTable.deleted_at.isNull()
+                }
+                .map { it[BookmarkedRecipeTable.recipe_id].value }
+                .toSet()
+            else -> RecipeTable
+                .selectAll()
+                .where {
+                    (RecipeTable.deleted_at.isNull()) and
+                        ((RecipeTable.creator_id eq EntityID(userId, UserTable)) or (RecipeTable.privacy eq "PUBLIC"))
+                }
+                .map { it[RecipeTable.id].value }
+                .toSet()
+        }
+
+        if (accessibleIds.isEmpty()) return@suspendTransaction emptyList()
+
+        // Step 3: Intersect with dietary restriction tag filters (AND logic — must have ALL tags)
+        var candidateIds = accessibleIds
+        for (tagEntityId in restrictionTagIds) {
+            val taggedIds = RecipeTagTable
+                .selectAll()
+                .where { RecipeTagTable.tagId eq tagEntityId }
+                .map { it[RecipeTagTable.recipeId].value }
+                .toSet()
+            candidateIds = candidateIds.intersect(taggedIds)
+            if (candidateIds.isEmpty()) return@suspendTransaction emptyList()
+        }
+
+        // Step 4: Apply time constraint
+        if (maxPrepTimeMinutes == null) {
+            candidateIds.toList()
+        } else {
+            val entityIds = candidateIds.map { EntityID(it, RecipeTable) }
+            RecipeTable
+                .selectAll()
+                .where {
+                    (RecipeTable.id inList entityIds) and
+                        ((RecipeTable.prep_time_minutes + RecipeTable.cook_time_minutes) lessEq maxPrepTimeMinutes)
+                }
+                .map { it[RecipeTable.id].value }
+        }
+    }
+
+    private fun toSyncMealPlanRecord(planRow: ResultRow): SyncMealPlanRecord {
+        val planId = planRow[MealPlanTable.id].value
+        val planEntityId = EntityID(planId, MealPlanTable)
+
+        val days = MealPlanDayTable
+            .selectAll()
+            .where { MealPlanDayTable.meal_plan_id eq planEntityId }
+            .orderBy(MealPlanDayTable.day_index to SortOrder.ASC)
+            .map { dayRow ->
+                SyncMealPlanDayDto(
+                    uuid = dayRow[MealPlanDayTable.id].value.toString(),
+                    dayIndex = dayRow[MealPlanDayTable.day_index],
+                    dinnerRecipeId = dayRow[MealPlanDayTable.dinner_recipe_id]?.value?.toString(),
+                    lunchRecipeId = dayRow[MealPlanDayTable.lunch_recipe_id]?.value?.toString()
+                )
+            }
+
+        return SyncMealPlanRecord(
+            plan = SyncMealPlanDto(
+                uuid = planId.toString(),
+                name = planRow[MealPlanTable.name],
+                status = planRow[MealPlanTable.status],
+                preferencesJson = planRow[MealPlanTable.preferences],
+                createdAt = planRow[MealPlanTable.created_at],
+                updatedAt = planRow[MealPlanTable.updated_at],
+                deletedAt = planRow[MealPlanTable.deleted_at],
+                days = days
+            ),
+            serverUpdatedAtMillis = planRow[MealPlanTable.server_updated_at].toEpochMilliseconds()
+        )
     }
 
     /**

--- a/src/main/kotlin/infrastructure/database/tables/MealPlanDayTable.kt
+++ b/src/main/kotlin/infrastructure/database/tables/MealPlanDayTable.kt
@@ -1,0 +1,15 @@
+package com.tenmilelabs.infrastructure.database.tables
+
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+
+object MealPlanDayTable : UUIDTable("meal_plan_days", "id") {
+    val meal_plan_id = reference("meal_plan_id", MealPlanTable, onDelete = ReferenceOption.CASCADE).index()
+    val day_index = integer("day_index")
+    val dinner_recipe_id = optReference("dinner_recipe_id", RecipeTable, onDelete = ReferenceOption.SET_NULL)
+    val lunch_recipe_id = optReference("lunch_recipe_id", RecipeTable, onDelete = ReferenceOption.SET_NULL)
+
+    init {
+        uniqueIndex(meal_plan_id, day_index)
+    }
+}

--- a/src/main/kotlin/infrastructure/database/tables/MealPlanTable.kt
+++ b/src/main/kotlin/infrastructure/database/tables/MealPlanTable.kt
@@ -1,0 +1,16 @@
+package com.tenmilelabs.infrastructure.database.tables
+
+import org.jetbrains.exposed.dao.id.UUIDTable
+import org.jetbrains.exposed.sql.ReferenceOption
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+
+object MealPlanTable : UUIDTable("meal_plans", "id") {
+    val user_id = reference("user_id", UserTable, onDelete = ReferenceOption.CASCADE).index()
+    val name = text("name")
+    val status = text("status")
+    val preferences = text("preferences")
+    val created_at = long("created_at")
+    val updated_at = long("updated_at")
+    val deleted_at = long("deleted_at").nullable()
+    val server_updated_at = timestamp("server_updated_at").index()
+}

--- a/src/main/kotlin/presentation/routes/MealPlanRoutes.kt
+++ b/src/main/kotlin/presentation/routes/MealPlanRoutes.kt
@@ -1,0 +1,48 @@
+package com.tenmilelabs.presentation.routes
+
+import com.tenmilelabs.application.dto.ErrorResponse
+import com.tenmilelabs.domain.service.MealPlanGenerationService
+import com.tenmilelabs.infrastructure.auth.userId
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import java.util.UUID
+
+fun Route.mealPlanRoutes(mealPlanGenerationService: MealPlanGenerationService) {
+    route("/meal-plans") {
+        post("/{mealPlanId}/generate") {
+            val userId = call.userId?.let {
+                try { UUID.fromString(it) } catch (_: IllegalArgumentException) { null }
+            } ?: run {
+                call.respond(HttpStatusCode.Unauthorized, ErrorResponse("User not authenticated"))
+                return@post
+            }
+
+            val mealPlanId = call.parameters["mealPlanId"]?.let {
+                try {
+                    UUID.fromString(it)
+                } catch (_: IllegalArgumentException) {
+                    null
+                }
+            } ?: run {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    ErrorResponse("mealPlanId path parameter is not a valid UUID")
+                )
+                return@post
+            }
+
+            val response = mealPlanGenerationService.startGeneration(mealPlanId, userId) ?: run {
+                call.respond(
+                    HttpStatusCode.NotFound,
+                    ErrorResponse("Meal plan not found or not owned by caller")
+                )
+                return@post
+            }
+
+            call.respond(HttpStatusCode.Accepted, response)
+        }
+    }
+}

--- a/src/main/kotlin/presentation/routes/Routing.kt
+++ b/src/main/kotlin/presentation/routes/Routing.kt
@@ -6,6 +6,7 @@ import com.tenmilelabs.domain.repository.FilterFields
 import com.tenmilelabs.domain.repository.RecipesRepository
 import com.tenmilelabs.domain.service.AuthService
 import com.tenmilelabs.domain.service.HomeLayoutService
+import com.tenmilelabs.domain.service.MealPlanGenerationService
 import com.tenmilelabs.domain.service.RecipesService
 import com.tenmilelabs.domain.service.SyncService
 import com.tenmilelabs.infrastructure.auth.userId
@@ -34,6 +35,7 @@ fun Application.configureRouting(
     authService: AuthService,
     syncService: SyncService,
     homeLayoutService: HomeLayoutService,
+    mealPlanGenerationService: MealPlanGenerationService,
 ) {
     // Install plugins related to routing
     install(ContentNegotiation) {
@@ -79,6 +81,7 @@ fun Application.configureRouting(
         authenticate("auth-jwt") {
             homeRoutes(homeLayoutService)
             syncRoutes(syncService)
+            mealPlanRoutes(mealPlanGenerationService)
             route("/recipes") {
 
                 get {

--- a/src/test/kotlin/domain/service/FakeSyncRepository.kt
+++ b/src/test/kotlin/domain/service/FakeSyncRepository.kt
@@ -3,10 +3,13 @@ package domain.service
 import com.tenmilelabs.application.dto.SyncBookmark
 import com.tenmilelabs.application.dto.SyncIngredient
 import com.tenmilelabs.application.dto.SyncLabel
+import com.tenmilelabs.application.dto.SyncMealPlanDto
+import com.tenmilelabs.application.dto.SyncMealPlanDayDto
 import com.tenmilelabs.application.dto.SyncRecipe
 import com.tenmilelabs.application.dto.SyncReferenceData
 import com.tenmilelabs.application.dto.SyncTag
 import com.tenmilelabs.application.dto.SyncUser
+import com.tenmilelabs.domain.repository.SyncMealPlanRecord
 import com.tenmilelabs.domain.repository.SyncRecipeRecord
 import com.tenmilelabs.domain.repository.SyncRepository
 import kotlinx.datetime.Instant
@@ -26,6 +29,8 @@ class FakeSyncRepository : SyncRepository {
     private val bookmarks = mutableMapOf<Pair<UUID, UUID>, SyncBookmark>()
     private val bookmarkServerTs = mutableMapOf<Pair<UUID, UUID>, Long>()
     private val inaccessibleRecipes = mutableSetOf<UUID>()
+    private val mealPlans = mutableMapOf<UUID, SyncMealPlanRecord>()
+    private val candidateRecipeIds = mutableListOf<UUID>()
 
     fun seedIngredient(uuid: UUID = UUID.randomUUID(), serverUpdatedAt: Long = 0L): UUID {
         ingredients[uuid] = SyncIngredient(
@@ -168,4 +173,47 @@ class FakeSyncRepository : SyncRepository {
                 key.first == userId && (bookmarkServerTs[key] ?: 0L) > sinceMillis
             }
             .map { it.value }
+
+    fun seedMealPlan(plan: SyncMealPlanDto, serverUpdatedAtMillis: Long = 0L): UUID {
+        val uuid = UUID.fromString(plan.uuid)
+        mealPlans[uuid] = SyncMealPlanRecord(plan = plan, serverUpdatedAtMillis = serverUpdatedAtMillis)
+        return uuid
+    }
+
+    fun seedCandidateRecipe(uuid: UUID = UUID.randomUUID()): UUID {
+        candidateRecipeIds += uuid
+        return uuid
+    }
+
+    override suspend fun getMealPlanForUser(uuid: UUID, userId: UUID): SyncMealPlanRecord? = mealPlans[uuid]
+
+    override suspend fun upsertMealPlan(plan: SyncMealPlanDto, userId: UUID, serverUpdatedAt: Instant) {
+        mealPlans[UUID.fromString(plan.uuid)] = SyncMealPlanRecord(
+            plan = plan,
+            serverUpdatedAtMillis = serverUpdatedAt.toEpochMilliseconds()
+        )
+    }
+
+    override suspend fun findDeltaMealPlans(userId: UUID, sinceMillis: Long): List<SyncMealPlanRecord> =
+        mealPlans.values.filter { it.serverUpdatedAtMillis > sinceMillis }.sortedBy { it.serverUpdatedAtMillis }
+
+    override suspend fun updateMealPlanStatus(planId: UUID, status: String, serverUpdatedAt: Instant) {
+        val existing = mealPlans[planId] ?: return
+        mealPlans[planId] = existing.copy(
+            plan = existing.plan.copy(status = status),
+            serverUpdatedAtMillis = serverUpdatedAt.toEpochMilliseconds()
+        )
+    }
+
+    override suspend fun replaceMealPlanDays(planId: UUID, days: List<SyncMealPlanDayDto>) {
+        val existing = mealPlans[planId] ?: return
+        mealPlans[planId] = existing.copy(plan = existing.plan.copy(days = days))
+    }
+
+    override suspend fun findCandidateRecipeIds(
+        userId: UUID,
+        recipeSource: String,
+        dietaryRestrictionTags: List<String>,
+        maxPrepTimeMinutes: Int?
+    ): List<UUID> = candidateRecipeIds.toList()
 }

--- a/src/test/kotlin/domain/service/MealPlanGenerationServiceTest.kt
+++ b/src/test/kotlin/domain/service/MealPlanGenerationServiceTest.kt
@@ -1,0 +1,249 @@
+package domain.service
+
+import com.tenmilelabs.domain.service.MealPlanGenerationService
+import com.tenmilelabs.domain.service.MealPlanPreferences
+import com.tenmilelabs.domain.service.MealType
+import com.tenmilelabs.domain.service.VarietyPreference
+import com.tenmilelabs.infrastructure.database.FakeSyncRepository
+import io.ktor.util.logging.KtorSimpleLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MealPlanGenerationServiceTest {
+
+    private val log = KtorSimpleLogger("test")
+    private val scope = CoroutineScope(SupervisorJob())
+
+    private fun makeService(repo: FakeSyncRepository) =
+        MealPlanGenerationService(repo, scope, log)
+
+    // ── parsePreferences ──────────────────────────────────────────────────────
+
+    @Test
+    fun `parsePreferences extracts all known fields`() {
+        val service = makeService(FakeSyncRepository())
+        val json = """
+            {
+              "planLengthDays": 5,
+              "mealType": "DINNER_AND_LUNCH",
+              "dietaryRestrictions": ["VEGAN", "GLUTEN_FREE"],
+              "recipeSource": "COLLECTION_ONLY",
+              "maxPrepTimeMinutes": 30,
+              "servingsPerMeal": 4,
+              "batchCooking": true,
+              "leftoverFriendly": false,
+              "varietyPreference": "HIGH"
+            }
+        """.trimIndent()
+
+        val prefs = service.parsePreferences(json)
+
+        assertEquals(5, prefs.planLengthDays)
+        assertEquals(MealType.DINNER_AND_LUNCH, prefs.mealType)
+        assertEquals(listOf("VEGAN", "GLUTEN_FREE"), prefs.dietaryRestrictions)
+        assertEquals("COLLECTION_ONLY", prefs.recipeSource)
+        assertEquals(30, prefs.maxPrepTimeMinutes)
+        assertEquals(4, prefs.servingsPerMeal)
+        assertTrue(prefs.batchCooking)
+        assertEquals(VarietyPreference.HIGH, prefs.varietyPreference)
+    }
+
+    @Test
+    fun `parsePreferences uses defaults for missing fields`() {
+        val service = makeService(FakeSyncRepository())
+        val prefs = service.parsePreferences("{}")
+
+        assertEquals(7, prefs.planLengthDays)
+        assertEquals(MealType.DINNER, prefs.mealType)
+        assertTrue(prefs.dietaryRestrictions.isEmpty())
+        assertEquals("INCLUDE_PUBLIC", prefs.recipeSource)
+        assertNull(prefs.maxPrepTimeMinutes)
+        assertEquals(VarietyPreference.HIGH, prefs.varietyPreference)
+    }
+
+    // ── assignRecipesToDays ───────────────────────────────────────────────────
+
+    @Test
+    fun `HIGH variety produces no duplicate dinner recipes when enough candidates exist`() {
+        val service = makeService(FakeSyncRepository())
+        val candidates = (1..7).map { UUID.randomUUID() }
+        val prefs = defaultPrefs(planLengthDays = 7, variety = VarietyPreference.HIGH)
+
+        val days = service.assignRecipesToDays(candidates, prefs)
+
+        assertEquals(7, days.size)
+        val usedIds = days.map { it.dinnerRecipeId }.filterNotNull()
+        assertEquals(usedIds.size, usedIds.distinct().size)
+    }
+
+    @Test
+    fun `HIGH variety with fewer candidates than days produces partial fill`() {
+        val service = makeService(FakeSyncRepository())
+        val candidates = listOf(UUID.randomUUID(), UUID.randomUUID())
+        val prefs = defaultPrefs(planLengthDays = 5, variety = VarietyPreference.HIGH)
+
+        val days = service.assignRecipesToDays(candidates, prefs)
+
+        assertEquals(5, days.size)
+        val filledCount = days.count { it.dinnerRecipeId != null }
+        assertEquals(2, filledCount)
+    }
+
+    @Test
+    fun `MEDIUM variety allows repeats after 3-day gap`() {
+        val service = makeService(FakeSyncRepository())
+        // 2 candidates, 7 days — must repeat but only after gap
+        val recipeA = UUID.randomUUID()
+        val recipeB = UUID.randomUUID()
+        val candidates = listOf(recipeA, recipeB)
+        val prefs = defaultPrefs(planLengthDays = 7, variety = VarietyPreference.MEDIUM)
+
+        val days = service.assignRecipesToDays(candidates, prefs)
+
+        assertEquals(7, days.size)
+        // No two consecutive days should share the same dinner recipe
+        for (i in 0 until days.size - 1) {
+            val current = days[i].dinnerRecipeId
+            val next = days[i + 1].dinnerRecipeId
+            if (current != null && next != null) {
+                assertTrue(current != next, "Consecutive days $i and ${i + 1} share the same recipe")
+            }
+        }
+    }
+
+    @Test
+    fun `LOW variety reuses candidates freely`() {
+        val service = makeService(FakeSyncRepository())
+        val candidates = listOf(UUID.randomUUID())
+        val prefs = defaultPrefs(planLengthDays = 5, variety = VarietyPreference.LOW)
+
+        val days = service.assignRecipesToDays(candidates, prefs)
+
+        assertEquals(5, days.size)
+        assertTrue(days.all { it.dinnerRecipeId != null })
+    }
+
+    @Test
+    fun `DINNER_AND_LUNCH populates both slots`() {
+        val service = makeService(FakeSyncRepository())
+        val candidates = (1..14).map { UUID.randomUUID() }
+        val prefs = defaultPrefs(
+            planLengthDays = 5,
+            mealType = MealType.DINNER_AND_LUNCH,
+            variety = VarietyPreference.HIGH
+        )
+
+        val days = service.assignRecipesToDays(candidates, prefs)
+
+        assertEquals(5, days.size)
+        assertTrue(days.all { it.dinnerRecipeId != null })
+        assertTrue(days.all { it.lunchRecipeId != null })
+    }
+
+    @Test
+    fun `DINNER meal type leaves lunch slots null`() {
+        val service = makeService(FakeSyncRepository())
+        val candidates = (1..5).map { UUID.randomUUID() }
+        val prefs = defaultPrefs(planLengthDays = 5, mealType = MealType.DINNER)
+
+        val days = service.assignRecipesToDays(candidates, prefs)
+
+        assertTrue(days.all { it.lunchRecipeId == null })
+    }
+
+    @Test
+    fun `batchCooking reuses previous day recipe on even-indexed days`() {
+        val service = makeService(FakeSyncRepository())
+        val candidates = (1..5).map { UUID.randomUUID() }
+        val prefs = defaultPrefs(planLengthDays = 4, variety = VarietyPreference.LOW, batchCooking = true)
+
+        val days = service.assignRecipesToDays(candidates, prefs)
+
+        assertEquals(4, days.size)
+        // Day 1 (index 1) should share dinner recipe with day 0
+        assertEquals(days[0].dinnerRecipeId, days[1].dinnerRecipeId)
+        // Day 3 (index 3) should share dinner recipe with day 2
+        assertEquals(days[2].dinnerRecipeId, days[3].dinnerRecipeId)
+    }
+
+    @Test
+    fun `empty candidates returns days with all null slots`() {
+        val service = makeService(FakeSyncRepository())
+        val prefs = defaultPrefs(planLengthDays = 3)
+
+        val days = service.assignRecipesToDays(emptyList(), prefs)
+
+        assertEquals(3, days.size)
+        assertTrue(days.all { it.dinnerRecipeId == null && it.lunchRecipeId == null })
+    }
+
+    // ── startGeneration ───────────────────────────────────────────────────────
+
+    @Test
+    fun `startGeneration returns null when plan is not found`() = runTest {
+        val repo = FakeSyncRepository()
+        val service = makeService(repo)
+
+        val result = service.startGeneration(UUID.randomUUID(), UUID.randomUUID())
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `startGeneration transitions plan to GENERATING and returns 202 payload`() = runTest {
+        val repo = FakeSyncRepository()
+        val planId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        repo.seedUser(uuid = userId)
+        repo.seedMealPlan(
+            plan = buildDraftPlan(planId, userId),
+            serverUpdatedAtMillis = 1000L
+        )
+
+        val service = makeService(repo)
+        val response = service.startGeneration(planId, userId)
+
+        assertNotNull(response)
+        assertEquals(planId.toString(), response.uuid)
+        assertEquals("GENERATING", response.status)
+        assertTrue(response.updatedAt > 0)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun defaultPrefs(
+        planLengthDays: Int = 5,
+        mealType: MealType = MealType.DINNER,
+        variety: VarietyPreference = VarietyPreference.HIGH,
+        batchCooking: Boolean = false
+    ) = MealPlanPreferences(
+        planLengthDays = planLengthDays,
+        mealType = mealType,
+        dietaryRestrictions = emptyList(),
+        recipeSource = "INCLUDE_PUBLIC",
+        maxPrepTimeMinutes = null,
+        servingsPerMeal = 2,
+        batchCooking = batchCooking,
+        leftoverFriendly = false,
+        varietyPreference = variety
+    )
+
+    private fun buildDraftPlan(planId: UUID, userId: UUID) =
+        com.tenmilelabs.application.dto.SyncMealPlanDto(
+            uuid = planId.toString(),
+            name = "Test Plan",
+            status = "DRAFT",
+            preferencesJson = """{"planLengthDays":3,"mealType":"DINNER","recipeSource":"INCLUDE_PUBLIC"}""",
+            createdAt = 1000L,
+            updatedAt = 1000L,
+            deletedAt = null,
+            days = emptyList()
+        )
+}

--- a/src/test/kotlin/infrastructure/auth/MealPlanIntegrationTest.kt
+++ b/src/test/kotlin/infrastructure/auth/MealPlanIntegrationTest.kt
@@ -1,0 +1,296 @@
+package infrastructure.auth
+
+import com.tenmilelabs.application.dto.*
+import com.tenmilelabs.application.service.module
+import com.tenmilelabs.domain.service.MealPlanGenerationService
+import com.tenmilelabs.infrastructure.database.FakeRecipesRepository
+import com.tenmilelabs.infrastructure.database.FakeRefreshTokenRepository
+import com.tenmilelabs.infrastructure.database.FakeSyncRepository
+import com.tenmilelabs.infrastructure.database.FakeUserRepository
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.testing.*
+import io.ktor.util.logging.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class MealPlanIntegrationTest {
+
+    @Test
+    fun `push DRAFT plan is persisted and returned on pull`() = testApplication {
+        val syncRepository = FakeSyncRepository()
+
+        application {
+            module(
+                configureDatabase = false,
+                recipeRepository = FakeRecipesRepository(),
+                userRepository = FakeUserRepository(),
+                refreshTokenRepository = FakeRefreshTokenRepository(),
+                syncRepository = syncRepository
+            )
+        }
+
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val auth = client.registerAndGetAuth()
+        val planId = UUID.randomUUID()
+
+        // Push a DRAFT meal plan
+        val pushResponse = client.post("/sync/push") {
+            bearerAuth(auth.token)
+            contentType(ContentType.Application.Json)
+            accept(ContentType.Application.Json)
+            setBody(
+                SyncPushRequest(
+                    recipes = emptyList(),
+                    mealPlans = listOf(buildDraftPlan(planId, updatedAt = 1000L))
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, pushResponse.status)
+        val pushBody = pushResponse.body<SyncPushResponse>()
+        assertEquals(1, pushBody.mealPlans.accepted.size)
+        assertEquals(planId.toString(), pushBody.mealPlans.accepted.first().uuid)
+        assertTrue(pushBody.mealPlans.conflicts.isEmpty())
+        assertTrue(pushBody.mealPlans.errors.isEmpty())
+
+        // Pull and verify the plan is returned
+        val pullResponse = client.get("/sync/pull?since=0&limit=100") {
+            bearerAuth(auth.token)
+            accept(ContentType.Application.Json)
+        }
+
+        assertEquals(HttpStatusCode.OK, pullResponse.status)
+        val pullBody = pullResponse.body<SyncPullResponse>()
+        val returnedPlan = pullBody.mealPlans.firstOrNull { it.uuid == planId.toString() }
+        assertNotNull(returnedPlan)
+        assertEquals("DRAFT", returnedPlan.status)
+        assertEquals("Week Plan", returnedPlan.name)
+    }
+
+    @Test
+    fun `push with newer server timestamp returns conflict`() = testApplication {
+        val syncRepository = FakeSyncRepository()
+        val planId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+
+        application {
+            module(
+                configureDatabase = false,
+                recipeRepository = FakeRecipesRepository(),
+                userRepository = FakeUserRepository(),
+                refreshTokenRepository = FakeRefreshTokenRepository(),
+                syncRepository = syncRepository
+            )
+        }
+
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val auth = client.registerAndGetAuth()
+
+        // Seed an existing plan with a high server timestamp
+        syncRepository.seedMealPlan(
+            buildDraftPlan(planId, updatedAt = 9000L),
+            serverUpdatedAtMillis = 9000L
+        )
+
+        // Push a stale version (client updatedAt < server serverUpdatedAt)
+        val pushResponse = client.post("/sync/push") {
+            bearerAuth(auth.token)
+            contentType(ContentType.Application.Json)
+            accept(ContentType.Application.Json)
+            setBody(
+                SyncPushRequest(
+                    recipes = emptyList(),
+                    mealPlans = listOf(buildDraftPlan(planId, updatedAt = 1000L))
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, pushResponse.status)
+        val body = pushResponse.body<SyncPushResponse>()
+        assertTrue(body.mealPlans.accepted.isEmpty())
+        assertEquals(1, body.mealPlans.conflicts.size)
+        assertEquals(planId.toString(), body.mealPlans.conflicts.first())
+    }
+
+    @Test
+    fun `generate endpoint returns 404 for unknown plan`() = testApplication {
+        application {
+            module(
+                configureDatabase = false,
+                recipeRepository = FakeRecipesRepository(),
+                userRepository = FakeUserRepository(),
+                refreshTokenRepository = FakeRefreshTokenRepository(),
+                syncRepository = FakeSyncRepository()
+            )
+        }
+
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val auth = client.registerAndGetAuth()
+
+        val response = client.post("/meal-plans/${UUID.randomUUID()}/generate") {
+            bearerAuth(auth.token)
+            accept(ContentType.Application.Json)
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `generate endpoint returns 202 and sets plan to GENERATING`() = testApplication {
+        val syncRepository = FakeSyncRepository()
+        val planId = UUID.randomUUID()
+
+        val testDispatcher = StandardTestDispatcher()
+        val testScope = CoroutineScope(SupervisorJob() + testDispatcher)
+        val log = KtorSimpleLogger("test")
+        val generationService = MealPlanGenerationService(syncRepository, testScope, log)
+
+        application {
+            module(
+                configureDatabase = false,
+                recipeRepository = FakeRecipesRepository(),
+                userRepository = FakeUserRepository(),
+                refreshTokenRepository = FakeRefreshTokenRepository(),
+                syncRepository = syncRepository,
+                mealPlanGenerationService = generationService
+            )
+        }
+
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val auth = client.registerAndGetAuth()
+
+        // Push a DRAFT plan first
+        client.post("/sync/push") {
+            bearerAuth(auth.token)
+            contentType(ContentType.Application.Json)
+            accept(ContentType.Application.Json)
+            setBody(SyncPushRequest(recipes = emptyList(), mealPlans = listOf(buildDraftPlan(planId))))
+        }
+
+        // Trigger generation
+        val generateResponse = client.post("/meal-plans/$planId/generate") {
+            bearerAuth(auth.token)
+            accept(ContentType.Application.Json)
+        }
+
+        assertEquals(HttpStatusCode.Accepted, generateResponse.status)
+        val body = generateResponse.body<GenerateMealPlanResponse>()
+        assertEquals(planId.toString(), body.uuid)
+        assertEquals("GENERATING", body.status)
+    }
+
+    @Test
+    fun `push DRAFT plan then generate then pull returns READY plan with days`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val syncRepository = FakeSyncRepository()
+        val planId = UUID.randomUUID()
+        val recipeId = syncRepository.seedCandidateRecipe()
+        val log = KtorSimpleLogger("test")
+        val generationScope = CoroutineScope(SupervisorJob() + testDispatcher)
+        val generationService = MealPlanGenerationService(syncRepository, generationScope, log)
+
+        // Seed plan directly and trigger generation
+        syncRepository.upsertMealPlan(buildDraftPlan(planId), UUID.randomUUID(), kotlinx.datetime.Clock.System.now())
+        generationService.startGeneration(planId, UUID.randomUUID())
+
+        // Advance coroutines to completion
+        advanceUntilIdle()
+
+        // Plan should now be READY with days
+        val record = syncRepository.getMealPlanForUser(planId, UUID.randomUUID())
+        assertNotNull(record)
+        assertEquals("READY", record.plan.status)
+        assertEquals(3, record.plan.days.size)
+        // 1 candidate + HIGH variety → first day is assigned, remainder are partial fills
+        assertTrue(record.plan.days.any { it.dinnerRecipeId == recipeId.toString() })
+    }
+
+    @Test
+    fun `soft-deleted plan is returned in pull with deletedAt set`() = testApplication {
+        val syncRepository = FakeSyncRepository()
+
+        application {
+            module(
+                configureDatabase = false,
+                recipeRepository = FakeRecipesRepository(),
+                userRepository = FakeUserRepository(),
+                refreshTokenRepository = FakeRefreshTokenRepository(),
+                syncRepository = syncRepository
+            )
+        }
+
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val auth = client.registerAndGetAuth()
+        val planId = UUID.randomUUID()
+
+        // Push a soft-deleted plan
+        client.post("/sync/push") {
+            bearerAuth(auth.token)
+            contentType(ContentType.Application.Json)
+            accept(ContentType.Application.Json)
+            setBody(
+                SyncPushRequest(
+                    recipes = emptyList(),
+                    mealPlans = listOf(buildDraftPlan(planId, deletedAt = 2000L))
+                )
+            )
+        }
+
+        val pullResponse = client.get("/sync/pull?since=0&limit=100") {
+            bearerAuth(auth.token)
+            accept(ContentType.Application.Json)
+        }
+
+        assertEquals(HttpStatusCode.OK, pullResponse.status)
+        val pullBody = pullResponse.body<SyncPullResponse>()
+        val deletedPlan = pullBody.mealPlans.firstOrNull { it.uuid == planId.toString() }
+        assertNotNull(deletedPlan)
+        assertNotNull(deletedPlan.deletedAt)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun buildDraftPlan(
+        planId: UUID = UUID.randomUUID(),
+        updatedAt: Long = 1000L,
+        deletedAt: Long? = null
+    ) = SyncMealPlanDto(
+        uuid = planId.toString(),
+        name = "Week Plan",
+        status = "DRAFT",
+        preferencesJson = """{"planLengthDays":3,"mealType":"DINNER","recipeSource":"INCLUDE_PUBLIC","varietyPreference":"HIGH"}""",
+        createdAt = 1000L,
+        updatedAt = updatedAt,
+        deletedAt = deletedAt,
+        days = listOf(
+            SyncMealPlanDayDto(uuid = UUID.randomUUID().toString(), dayIndex = 0, dinnerRecipeId = null, lunchRecipeId = null)
+        )
+    )
+
+    private suspend fun HttpClient.registerAndGetAuth(): AuthResponse {
+        val registerRequest = RegisterRequest(
+            email = "mealplan-test-${UUID.randomUUID()}@example.com",
+            username = "mealplanuser-${UUID.randomUUID().toString().take(8)}",
+            password = "TestPassword123!"
+        )
+        val registerResponse = post("/auth/register") {
+            contentType(ContentType.Application.Json)
+            setBody(registerRequest)
+        }
+        assertEquals(HttpStatusCode.Created, registerResponse.status)
+        return registerResponse.body()
+    }
+}

--- a/src/test/kotlin/infrastructure/database/FakeSyncRepository.kt
+++ b/src/test/kotlin/infrastructure/database/FakeSyncRepository.kt
@@ -3,10 +3,13 @@ package com.tenmilelabs.infrastructure.database
 import com.tenmilelabs.application.dto.SyncBookmark
 import com.tenmilelabs.application.dto.SyncIngredient
 import com.tenmilelabs.application.dto.SyncLabel
+import com.tenmilelabs.application.dto.SyncMealPlanDayDto
+import com.tenmilelabs.application.dto.SyncMealPlanDto
 import com.tenmilelabs.application.dto.SyncRecipe
 import com.tenmilelabs.application.dto.SyncReferenceData
 import com.tenmilelabs.application.dto.SyncTag
 import com.tenmilelabs.application.dto.SyncUser
+import com.tenmilelabs.domain.repository.SyncMealPlanRecord
 import com.tenmilelabs.domain.repository.SyncRecipeRecord
 import com.tenmilelabs.domain.repository.SyncRepository
 import kotlinx.datetime.Instant
@@ -27,6 +30,10 @@ class FakeSyncRepository : SyncRepository {
     private val bookmarkServerTs = mutableMapOf<Pair<UUID, UUID>, Long>()
     // accessible recipe ids (by default, all seeded recipes are accessible)
     private val inaccessibleRecipes = mutableSetOf<UUID>()
+    // meal plans: key=planId, value=record with server timestamp
+    private val mealPlans = mutableMapOf<UUID, SyncMealPlanRecord>()
+    // candidate recipe IDs for generation (injectable per-test)
+    private val candidateRecipeIds = mutableListOf<UUID>()
 
     fun seedIngredient(uuid: UUID = UUID.randomUUID(), serverUpdatedAt: Long = 0L): UUID {
         ingredients[uuid] = SyncIngredient(
@@ -89,6 +96,17 @@ class FakeSyncRepository : SyncRepository {
 
     fun makeRecipeInaccessible(recipeId: UUID) {
         inaccessibleRecipes += recipeId
+    }
+
+    fun seedMealPlan(plan: SyncMealPlanDto, serverUpdatedAtMillis: Long = 0L): UUID {
+        val uuid = UUID.fromString(plan.uuid)
+        mealPlans[uuid] = SyncMealPlanRecord(plan = plan, serverUpdatedAtMillis = serverUpdatedAtMillis)
+        return uuid
+    }
+
+    fun seedCandidateRecipe(uuid: UUID = UUID.randomUUID()): UUID {
+        candidateRecipeIds += uuid
+        return uuid
     }
 
     override suspend fun getRecipe(uuid: UUID): SyncRecipeRecord? = recipes[uuid]
@@ -173,4 +191,41 @@ class FakeSyncRepository : SyncRepository {
                 key.first == userId && (bookmarkServerTs[key] ?: 0L) > sinceMillis
             }
             .map { it.value }
+
+    // ── Meal Plans ────────────────────────────────────────────────────────────
+
+    override suspend fun getMealPlanForUser(uuid: UUID, userId: UUID): SyncMealPlanRecord? =
+        mealPlans[uuid]
+
+    override suspend fun upsertMealPlan(plan: SyncMealPlanDto, userId: UUID, serverUpdatedAt: Instant) {
+        mealPlans[UUID.fromString(plan.uuid)] = SyncMealPlanRecord(
+            plan = plan,
+            serverUpdatedAtMillis = serverUpdatedAt.toEpochMilliseconds()
+        )
+    }
+
+    override suspend fun findDeltaMealPlans(userId: UUID, sinceMillis: Long): List<SyncMealPlanRecord> =
+        mealPlans.values
+            .filter { it.serverUpdatedAtMillis > sinceMillis }
+            .sortedBy { it.serverUpdatedAtMillis }
+
+    override suspend fun updateMealPlanStatus(planId: UUID, status: String, serverUpdatedAt: Instant) {
+        val existing = mealPlans[planId] ?: return
+        mealPlans[planId] = existing.copy(
+            plan = existing.plan.copy(status = status),
+            serverUpdatedAtMillis = serverUpdatedAt.toEpochMilliseconds()
+        )
+    }
+
+    override suspend fun replaceMealPlanDays(planId: UUID, days: List<SyncMealPlanDayDto>) {
+        val existing = mealPlans[planId] ?: return
+        mealPlans[planId] = existing.copy(plan = existing.plan.copy(days = days))
+    }
+
+    override suspend fun findCandidateRecipeIds(
+        userId: UUID,
+        recipeSource: String,
+        dietaryRestrictionTags: List<String>,
+        maxPrepTimeMinutes: Int?
+    ): List<UUID> = candidateRecipeIds.toList()
 }


### PR DESCRIPTION

Implements the backend for the Android client's meal planning feature. Covers database schema, sync protocol extensions (push + pull), and an async AI-style generation endpoint.

---

### Schema

Two new tables managed by `SchemaUtils.create` (no migration framework):

- **`meal_plans`** — `id UUID PK`, `user_id FK → users`, `name`, `status` (DRAFT / GENERATING / READY / ARCHIVED), `preferences TEXT` (JSON string), `created_at BIGINT`, `updated_at BIGINT`, `deleted_at BIGINT?`, `server_updated_at TIMESTAMPTZ` (indexed). Follows the existing dual-timestamp pattern for cursor-based sync.
- **`meal_plan_days`** — `id UUID PK`, `meal_plan_id FK → meal_plans CASCADE`, `day_index INT`, `dinner_recipe_id UUID? FK → recipes SET NULL`, `lunch_recipe_id UUID? FK → recipes SET NULL`. Unique index on `(meal_plan_id, day_index)`.

---

### Sync protocol extensions

**`POST /sync/push`**

- `SyncPushRequest` gains `mealPlans: List<SyncMealPlanDto> = emptyList()`.
- Per-plan processing in `SyncService.processMealPlans`: validate UUID, conflict-check (`serverUpdatedAtMillis > plan.updatedAt` → last-writer-wins), upsert plan + atomically replace days.
- `SyncPushResponse` gains `mealPlans: MealPlanPushResults` with `accepted`, `conflicts` (UUID list), and `errors`. Soft-delete: `deletedAt` non-null is persisted and included in future pulls.

**`GET /sync/pull`**

- `SyncPullResponse` gains `mealPlans: List<SyncMealPlanDto> = emptyList()`.
- Filter: `WHERE user_id = :userId AND server_updated_at > :since`. Includes soft-deleted plans so the client can tombstone them. Days are nested inside each plan DTO (no separate pull needed).

---

### Meal plan generation endpoint

**`POST /meal-plans/{mealPlanId}/generate`** — JWT-authenticated, returns `202 Accepted`.

1. Validates caller owns the plan (404 otherwise).
2. Synchronously transitions status → `GENERATING`, returns `{ uuid, status, updatedAt }`.
3. Launches a background coroutine (scoped to application lifecycle via `SupervisorJob`) that:
    - Queries candidate recipes via `SyncRepository.findCandidateRecipeIds` using preferences:
        - `recipeSource = COLLECTION_ONLY` → bookmarked recipes only
        - `recipeSource = INCLUDE_PUBLIC` → owned + PUBLIC
        - `dietaryRestrictions` → tag name intersection (AND logic, case-insensitive)
        - `maxPrepTimeMinutes` → `prep_time_minutes + cook_time_minutes ≤ N`
    - Assigns recipes to day slots using `MealPlanGenerationService.assignRecipesToDays`:
        - `varietyPreference = HIGH` → no repeats; unfilled slots stay null (partial fill)
        - `varietyPreference = MEDIUM` → no repeats within a 3-day window; cycles when blocked
        - `varietyPreference = LOW` → round-robin cycling, always fills
        - `batchCooking = true` → odd-indexed days reuse the previous day's recipe
        - `mealType = DINNER` → only `dinner_recipe_id` populated; `lunch_recipe_id` stays null
    - Atomically replaces `meal_plan_days`, then transitions status → `READY`.
    - Client picks up READY status on next pull.